### PR TITLE
Added additional length in stage1 for use with 8.1 FIRM0 and 10.0 FIRM1

### DIFF
--- a/common/payload_stage1.ld
+++ b/common/payload_stage1.ld
@@ -4,7 +4,7 @@ ENTRY(_start)
 
 MEMORY
   {
-  ram : ORIGIN = 0x0808FA00, LENGTH = 0x5k
+  ram : ORIGIN = 0x0808FA00, LENGTH = 0x6k
   }
 
 SECTIONS


### PR DESCRIPTION
To use with 8.1 FIRM0 and 10.0 FIRM1. This allows us to have 0x1k more storage in stage1
